### PR TITLE
feat: expose env field in migration API container details

### DIFF
--- a/projects/api/src/server/migration.controller.ts
+++ b/projects/api/src/server/migration.controller.ts
@@ -104,6 +104,7 @@ export class MigrationController {
                 url: source.url,
               }
             : null,
+          env: container.env,
         };
         return containerDto;
       }),

--- a/projects/api/src/server/migration/dto/migration-container.dto.ts
+++ b/projects/api/src/server/migration/dto/migration-container.dto.ts
@@ -30,4 +30,5 @@ export class MigrationContainerDetailDto extends MigrationContainerDto {
   additionalNetworks?: string[];
   registry?: MigrationRegistryDto | null;
   source?: MigrationSourceDto | null;
+  env?: string;
 }


### PR DESCRIPTION
Add env string to MigrationContainerDetailDto and include it in the project details endpoint response. This allows TurboOps to import environment variables during deploy.party → TurboOps migration.