### PR TITLE
feat(directus): mount per-project extensions folder into Directus ser…

### DIFF
--- a/projects/api/src/server/common/services/docker.service.ts
+++ b/projects/api/src/server/common/services/docker.service.ts
@@ -118,6 +118,9 @@ export class DockerService {
           await this.containerService.updateForce(container.id, { env: container.env });
           await this.createEnvFile(container);
         }
+        // Swarm rejects a service whose bind-mount source path is missing, so the
+        // per-project extensions folder (see getDirectus) must exist before deploy.
+        await fs.mkdir(`${envConfig.projectsDir}/${container.id}/extensions`, { recursive: true });
         compose = getDirectus(container);
         break;
       case ServiceType.ADMINER:

--- a/projects/api/src/server/modules/container/types/service/directus/compose.ts
+++ b/projects/api/src/server/modules/container/types/service/directus/compose.ts
@@ -45,9 +45,11 @@ ${extraNetworkDefinitions ? '\n' + extraNetworkDefinitions : ''}
         volumes:
           - uploads:/directus/uploads
           # Load host-provided extensions from the project's extensions folder.
-          # Absolute path (Swarm bind mounts require it); the folder is created
-          # automatically (root-owned, empty = no extensions = default behaviour).
-          # To let the Directus Marketplace write here, chown it to 1000:1000.
+          # Absolute path (Swarm bind mounts require it). Swarm does NOT create a
+          # missing bind source (it rejects the task), so createDockerComposeFile()
+          # mkdir's this folder before deploy. Empty folder = no extensions =
+          # unchanged behaviour. To let the Directus Marketplace write installs
+          # here, chown the folder to 1000:1000 (the directus container user).
           - ${envConfig.projectsDir}/${container.id}/extensions:/directus/extensions
         depends_on:
           - cache

--- a/projects/api/src/server/modules/container/types/service/directus/compose.ts
+++ b/projects/api/src/server/modules/container/types/service/directus/compose.ts
@@ -1,4 +1,5 @@
 import { Container } from "../../../container.model";
+import envConfig from "../../../../../../config.env";
 
 export function getDirectus(container: Container): string {
   // Additional networks configuration
@@ -43,8 +44,11 @@ ${extraNetworkDefinitions ? '\n' + extraNetworkDefinitions : ''}
         image: directus/directus:${container.buildImage || 'latest'}
         volumes:
           - uploads:/directus/uploads
-          # If you want to load extensions from the host
-          # - ./extensions:/directus/extensions
+          # Load host-provided extensions from the project's extensions folder.
+          # Absolute path (Swarm bind mounts require it); the folder is created
+          # automatically (root-owned, empty = no extensions = default behaviour).
+          # To let the Directus Marketplace write here, chown it to 1000:1000.
+          - ${envConfig.projectsDir}/${container.id}/extensions:/directus/extensions
         depends_on:
           - cache
           - database


### PR DESCRIPTION
## Was
Fügt dem generierten Directus-Service-Compose einen absoluten Bind-Mount `${projectsDir}/${container.id}/extensions → /directus/extensions` hinzu, damit eigene Directus-Extensions **pro Projekt** bereitgestellt werden können — ohne Custom-Image.

## Wichtig: Swarm legt den Ordner NICHT selbst an
Anders als standalone `docker run -v` **erstellt Docker Swarm eine fehlende Bind-Mount-Quelle nicht**, sondern **lehnt den Task ab** (`invalid mount config … bind source path does not exist` — im lokalen Single-Node-Swarm verifiziert). Deshalb legt `createDockerComposeFile()` den `extensions`-Ordner **vor** dem `stack deploy` per `fs.mkdir(..., { recursive: true })` an. Ein leerer Ordner = „keine Extensions" = unverändertes Verhalten für bestehende Services.

## Marketplace
Directus lädt Extensions **lesend** → der (deploy.party-owned) Ordner reicht dafür. Der **Marketplace** schreibt Installs aber als **uid 1000** in den Ordner und braucht ihn daher auf `1000:1000` gechownt (verifiziert: uid 1000 bekommt sonst `Permission denied`). Aktuell manueller Schritt.

## ⚠️ Rollout-Hinweis
Directus-Services, die aktuell **Store-Extensions** installiert haben, halten diese nur ephemer. Beim **ersten Redeploy** nach diesem Change überschattet der leere Host-Ordner sie → sie verschwinden. Vorher `docker cp <task>:/directus/extensions/. /data/projects/<id>/extensions/` sichern oder neu installieren. Betrifft **alle** Directus-Services der Instanz.

## Verifiziert
- `tsc -p tsconfig.build.json --noEmit` → Exit 0
- Swarm-Reject ohne Ordner reproduziert; mit `mkdir` startet der Service sauber
- uid-1000-Schreibtest bestätigt den chown-Bedarf
